### PR TITLE
Implement xmlrpc options, such as allow_none

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,3 +109,6 @@ Contributors
 - Chris McDonough, 2010/11/08
 
 - Tres Seaver, 2010/11/09
+
+- Guillaume Gauvrit, 2012/12/08
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,6 +161,34 @@ client:
    >>> s.say_goodbye()
    Goodbye, cruel world
 
+
+.. _configuration:
+
+Configuration XML-RPC
+~~~~~~~~~~~~~~~~~~~~~
+
+XML RPC serialization can be configured as in the `Python Standard 
+Library <http://docs.python.org/2/library/xmlrpclib.html>`_.
+
+  - ``nil`` xml rpc extension
+  - cast every xmlrpc ``datetime.iso8601`` to python `datetime.datetime` type
+  - use an xml encoding in the response
+
+These parameters are set in the :mod:`pyramid` .ini configuration file
+like below:
+
+.. code-block:: ini
+
+   [app:main]
+
+   pyramid.includes =
+     pyramid_xmlrpc
+
+   xmlrpc.encoding = utf-8
+   xmlrpc.allow_none = True
+   xmlrpc.datetime = True
+
+
 .. _api:
 
 API Documentation for :mod:`pyramid_xmlrpc`

--- a/pyramid_xmlrpc/__init__.py
+++ b/pyramid_xmlrpc/__init__.py
@@ -1,6 +1,7 @@
 import xmlrpclib
 import webob
 
+
 def xmlrpc_marshal(data):
     """ Marshal a Python data structure into an XML document suitable
     for use as an XML-RPC response and return the document.  If
@@ -9,7 +10,8 @@ def xmlrpc_marshal(data):
     if isinstance(data, xmlrpclib.Fault):
         return xmlrpclib.dumps(data)
     else:
-        return xmlrpclib.dumps((data,),  methodresponse=True)
+        return xmlrpclib.dumps((data,), methodresponse=True)
+
 
 def xmlrpc_response(data):
     """ Marshal a Python data structure into a webob ``Response``
@@ -22,6 +24,7 @@ def xmlrpc_response(data):
     response.content_length = len(xml)
     return response
 
+
 def parse_xmlrpc_request(request):
     """ Deserialize the body of a request from an XML-RPC request
     document into a set of params and return a two-tuple.  The first
@@ -32,6 +35,7 @@ def parse_xmlrpc_request(request):
         raise ValueError('Body too large (%s bytes)' % request.content_length)
     params, method = xmlrpclib.loads(request.body)
     return params, method
+
 
 def xmlrpc_view(wrapped):
     """ This decorator turns functions which accept params and return Python
@@ -83,23 +87,24 @@ def xmlrpc_view(wrapped):
     In other words do *not* decorate it in :func:`~pyramid_xmlrpc.xmlrpc_view`,
     then :class:`~pyramid.view.view_config`; it won't work.
     """
-    
+
     def _curried(context, request):
         params, method = parse_xmlrpc_request(request)
         value = wrapped(context, *params)
         return xmlrpc_response(value)
     _curried.__name__ = wrapped.__name__
-    _curried.__grok_module__ = wrapped.__module__ 
+    _curried.__grok_module__ = wrapped.__module__
 
     return _curried
-    
+
+
 class XMLRPCView:
     """A base class for a view that serves multiple methods by XML-RPC.
 
     Subclass and add your methods as described in the documentation.
     """
 
-    def __init__(self,context,request):
+    def __init__(self, context, request):
         self.context = context
         self.request = request
 
@@ -113,7 +118,7 @@ class XMLRPCView:
         .. warning::
           Do not override this method in any subclass if you
           want XML-RPC to continute to work!
-          
+
         """
         params, method = parse_xmlrpc_request(self.request)
-        return xmlrpc_response(getattr(self,method)(*params))
+        return xmlrpc_response(getattr(self, method)(*params))

--- a/pyramid_xmlrpc/tests.py
+++ b/pyramid_xmlrpc/tests.py
@@ -1,8 +1,10 @@
+# -*- coding: utf-8 -*-
 import unittest
 from pyramid import testing
 
 
 class TestXMLRPCMarshal(unittest.TestCase):
+
     def _callFUT(self, value):
         from pyramid_xmlrpc import xmlrpc_marshal
         return xmlrpc_marshal(value)
@@ -22,9 +24,10 @@ class TestXMLRPCMarshal(unittest.TestCase):
 
 
 class TestXMLRPResponse(unittest.TestCase):
-    def _callFUT(self, value):
+
+    def _callFUT(self, value, allow_none=False, charset=None):
         from pyramid_xmlrpc import xmlrpc_response
-        return xmlrpc_response(value)
+        return xmlrpc_response(value, allow_none, charset)
 
     def test_xmlrpc_response(self):
         import xmlrpclib
@@ -36,11 +39,28 @@ class TestXMLRPResponse(unittest.TestCase):
         self.assertEqual(response.content_length, len(response.body))
         self.assertEqual(response.status, '200 OK')
 
+    def test_xmlrpc_response_nil(self):
+        import xmlrpclib
+        data = None
+        self.assertRaises(TypeError, self._callFUT, data)
+        response = self._callFUT(data, allow_none=True).body
+        self.assertIsNone(xmlrpclib.loads(response)[0][0])
+
+    def test_xmlrpc_response_charset(self):
+        import xmlrpclib
+        data = u"é"
+        self.assertRaises(UnicodeEncodeError, self._callFUT, data, False,
+                          "us-ascii")
+        response = self._callFUT(data, charset="iso-8859-1").body
+        self.assertEqual(response.split('>', 1)[0],
+                         "<?xml version='1.0' encoding='iso-8859-1'?")
+
 
 class TestParseXMLRPCRequest(unittest.TestCase):
-    def _callFUT(self, request):
+
+    def _callFUT(self, request, use_datetime=0):
         from pyramid_xmlrpc import parse_xmlrpc_request
-        return parse_xmlrpc_request(request)
+        return parse_xmlrpc_request(request, use_datetime)
 
     def test_normal(self):
         import xmlrpclib
@@ -58,8 +78,23 @@ class TestParseXMLRPCRequest(unittest.TestCase):
         request.content_length = 1 << 24
         self.assertRaises(ValueError, self._callFUT, request)
 
+    def test_datetime(self):
+        import datetime
+        import xmlrpclib
+        from pyramid_xmlrpc import parse_xmlrpc_request
+        param = datetime.datetime.now()
+        packet = xmlrpclib.dumps((param,), methodname='__call__')
+        request = testing.DummyRequest()
+        request.body = packet
+        request.content_length = len(packet)
+        params, method = self._callFUT(request)
+        self.assertEqual(params[0].__class__, xmlrpclib.DateTime)
+        params, method = self._callFUT(request, use_datetime=True)
+        self.assertEqual(params[0].__class__, datetime.datetime)
+
 
 class TestDecorator(unittest.TestCase):
+
     def _callFUT(self, unwrapped):
         from pyramid_xmlrpc import xmlrpc_view
         return xmlrpc_view(unwrapped)
@@ -113,3 +148,89 @@ class TestBaseClass(unittest.TestCase):
         response = instance()
         self.assertEqual(response.body, xmlrpclib.dumps((param,),
                                                         methodresponse=True))
+
+    def test_marshalling_none(self):
+        from pyramid_xmlrpc import XMLRPCView
+
+        class Test(XMLRPCView):
+            allow_none = True
+
+            def a_method(self, param):
+                return None
+
+        import xmlrpclib
+        packet = xmlrpclib.dumps((None,), methodname='a_method',
+                                 allow_none=True)
+        request = testing.DummyRequest()
+        request.body = packet
+        request.content_length = len(packet)
+
+        # instantiate the view
+        context = testing.DummyModel()
+        instance = Test(context, request)
+        # exercise it
+        response = instance()
+        self.assertEqual(response.body, xmlrpclib.dumps((None,),
+                                                        allow_none=True,
+                                                        methodresponse=True))
+
+    def test_parse_datetime(self):
+        from pyramid_xmlrpc import XMLRPCView
+
+        class Test(XMLRPCView):
+            use_datetime = True
+
+            def a_method(self, param):
+                Test.datetime = param
+                return param
+
+        import xmlrpclib
+        import datetime
+        packet = xmlrpclib.dumps((datetime.datetime.now(),),
+                                 methodname='a_method')
+        request = testing.DummyRequest()
+        request.body = packet
+        request.content_length = len(packet)
+
+        # instantiate the view
+        context = testing.DummyModel()
+        instance = Test(context, request)
+        # exercise it
+        response = instance()
+        self.assertEqual(Test.datetime.__class__, datetime.datetime)
+
+    def test_charset(self):
+        from pyramid_xmlrpc import XMLRPCView
+
+        class Test(XMLRPCView):
+            charset = 'iso-8859-1'
+
+            def a_method(self, param):
+                return param
+
+        import xmlrpclib
+        packet = xmlrpclib.dumps(('param',), methodname='a_method')
+        request = testing.DummyRequest()
+        request.body = packet
+        request.content_length = len(packet)
+
+        # instantiate the view
+        context = testing.DummyModel()
+        instance = Test(context, request)
+        # exercise it
+        response = instance()
+        self.assertEqual(response.body.split('>', 1)[0],
+                         "<?xml version='1.0' encoding='iso-8859-1'?")
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_includeme(self):
+        from pyramid_xmlrpc import includeme, XMLRPCView
+
+        settings = {'xmlrpc.charset': 'iso-8859-15',
+                    'xmlrpc.allow_none': 'true'}
+        self.config = testing.setUp(settings=settings)
+        self.config.include(includeme)
+        self.assertEqual(XMLRPCView.charset, 'iso-8859-15')
+        self.assertTrue(XMLRPCView.allow_none)

--- a/pyramid_xmlrpc/tests.py
+++ b/pyramid_xmlrpc/tests.py
@@ -1,11 +1,12 @@
 import unittest
 from pyramid import testing
 
+
 class TestXMLRPCMarshal(unittest.TestCase):
     def _callFUT(self, value):
         from pyramid_xmlrpc import xmlrpc_marshal
         return xmlrpc_marshal(value)
-        
+
     def test_xmlrpc_marshal_normal(self):
         data = 1
         marshalled = self._callFUT(data)
@@ -19,11 +20,12 @@ class TestXMLRPCMarshal(unittest.TestCase):
         data = self._callFUT(fault)
         self.assertEqual(data, xmlrpclib.dumps(fault))
 
+
 class TestXMLRPResponse(unittest.TestCase):
     def _callFUT(self, value):
         from pyramid_xmlrpc import xmlrpc_response
         return xmlrpc_response(value)
-        
+
     def test_xmlrpc_response(self):
         import xmlrpclib
         data = 1
@@ -33,7 +35,8 @@ class TestXMLRPResponse(unittest.TestCase):
                                                         methodresponse=True))
         self.assertEqual(response.content_length, len(response.body))
         self.assertEqual(response.status, '200 OK')
-        
+
+
 class TestParseXMLRPCRequest(unittest.TestCase):
     def _callFUT(self, request):
         from pyramid_xmlrpc import parse_xmlrpc_request
@@ -54,6 +57,7 @@ class TestParseXMLRPCRequest(unittest.TestCase):
         request = testing.DummyRequest()
         request.content_length = 1 << 24
         self.assertRaises(ValueError, self._callFUT, request)
+
 
 class TestDecorator(unittest.TestCase):
     def _callFUT(self, unwrapped):
@@ -76,15 +80,17 @@ class TestDecorator(unittest.TestCase):
         request.content_length = len(packet)
         response = wrapped(context, request)
         self.assertEqual(response.body, xmlrpclib.dumps((param,),
-                                                       methodresponse=True))
+                                                        methodresponse=True))
+
 
 class TestBaseClass(unittest.TestCase):
 
     def test_normal(self):
-        
+
         from pyramid_xmlrpc import XMLRPCView
+
         class Test(XMLRPCView):
-            def a_method(self,param):
+            def a_method(self, param):
                 return param
 
         # set up a request
@@ -97,7 +103,7 @@ class TestBaseClass(unittest.TestCase):
 
         # instantiate the view
         context = testing.DummyModel()
-        instance = Test(context,request)
+        instance = Test(context, request)
 
         # these are fair game for the methods to use if they want
         self.failUnless(instance.context is context)
@@ -106,4 +112,4 @@ class TestBaseClass(unittest.TestCase):
         # exercise it
         response = instance()
         self.assertEqual(response.body, xmlrpclib.dumps((param,),
-                                                       methodresponse=True))
+                                                        methodresponse=True))


### PR DESCRIPTION
Implement allow_none, use_datetime, and charset.  
An includeme method has been added to configure those params
via the ini file. 

It is also possible to subclass the XMLRPCView.
